### PR TITLE
Correct the Interpreter paths

### DIFF
--- a/add.py
+++ b/add.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-3.0-or-later
 # (c) Sarthak Roy (sarthakroy2002) <sarthakroy2002@gmail.com>
 #

--- a/env.py
+++ b/env.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-3.0-or-later
 # (c) CyberJalagam <jaishnavprasad@disroot.org>
 

--- a/gsi.py
+++ b/gsi.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-3.0-or-later
 # (c) TechyMinati ( Aryan Sinha ) <sinha.aryan03@gmail.com>
 import os

--- a/los.py
+++ b/los.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-3.0-or-later
 # (c) TechyMinati ( Aryan Sinha ) <sinha.aryan03@gmail.com>
 import os

--- a/pbrp.py
+++ b/pbrp.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 # SPDX-License-Identifier: GPL-3.0-or-later
 # (c) eun0115 ( eun ) <gianpaoloestacio5@gmail.com>
 import os


### PR DESCRIPTION
* python scripts should use python3 instead of bash.

Signed-off-by: Sushrut1101 <guptasushrut@gmail.com>